### PR TITLE
When ending a season and ending a run, fisher returns to port

### DIFF
--- a/public/js/fish.js
+++ b/public/js/fish.js
@@ -326,6 +326,14 @@ function changeLocation() {
     }
 
 }
+
+function resetLocation() {
+    var btn = $("#changeLocation");
+    goToPort();
+    btn.data('location', 'port');
+    btn.html(msgs.buttons_goToSea);
+}
+
 function goToSea() {
     socket.emit('goToSea');
     $('#attempt-fish').removeAttr('disabled');
@@ -371,11 +379,13 @@ function receiveStatus(data) {
 }
 
 function endSeason() {
+    resetLocation();
     updateWarning();
     disableButtons();
 }
 
 function endRun(trigger) {
+    resetLocation();
     st.status = 'over';
 
     disableButtons();


### PR DESCRIPTION
Closes #194 

The function "resetLocation" is called whenever a run ends or a season ends.
I believe that catches both potential cases that caused the issues described in #194, correct?