### PR TITLE
Ocean edge cases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "rmkfish",
-  "version": "0.1.0",
+  "name": "fishsim",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "rmkfish",
-      "version": "0.1.0",
+      "name": "fishsim",
+      "version": "5.1.0",
       "hasInstallScript": true,
       "dependencies": {
         "@babel/polyfill": "^7.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fishsim",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "private": true,
   "repository": {
     "type": "git",

--- a/src/engine/fisher.js
+++ b/src/engine/fisher.js
@@ -19,6 +19,10 @@ exports.Fisher = function Fisher(name, type, params, o) {
     return this.type === 'bot';
   };
 
+  this.isHuman = function() {
+    return this.type === 'human';
+  };
+
   this.isErratic = function() {
     return this.params.predictability === 'erratic';
   };

--- a/src/engine/ocean.js
+++ b/src/engine/ocean.js
@@ -51,6 +51,16 @@ exports.Ocean = function Ocean(mw, incomingIo, incomingIoAdmin, om) {
     return this.fishers.length === this.microworld.params.numFishers;
   };
 
+  this.hasNoHumans = function() {
+    for (var i in this.fishers) {
+      if (this.fishers[i].isHuman()) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+
   this.addFisher = function(pId) {
     this.fishers.push(new Fisher(pId, 'human', null, this));
     this.log.info('Human fisher ' + pId + ' joined.');
@@ -60,12 +70,18 @@ exports.Ocean = function Ocean(mw, incomingIo, incomingIoAdmin, om) {
   this.removeFisher = function(pId) {
     for (var i in this.fishers) {
       var fisher = this.fishers[i];
-      if (!fisher.isBot() && fisher.name === pId) {
+      if (fisher.isHuman() && fisher.name === pId) {
         this.resume(pId); // just in case this fisher paused the game just before leaving!
         this.fishers.splice(i, 1);
+        this.log.info('Human fisher ' + pId + ' left.');
       }
     }
-    this.log.info('Human fisher ' + pId + ' left.');
+    if (this.hasNoHumans()) {
+      // Ocean used to hang around for other humans to show up.
+      // That can lead to problems if the corresponding microworld is still in test mode and gets changed.
+      // Experimenter will assume incorrectly that when the ocean eventually runs, that it has the latest settings. 
+      this.endOcean("No humans remaining");
+    }
   };
 
   this.findFisherIndex = function(pId) {


### PR DESCRIPTION
When a human fisher leaves an ocean in setup mode, the ocean continues to wait for other humans, for days or longer.
That can lead to problems if the corresponding microworld is still in test mode and gets changed,
as the experimenter will assume incorrectly that when the ocean eventually runs, that it has the latest settings. 
Solution: in Ocean.removeFisher(), if the last human leaves, end the ocean. 